### PR TITLE
Fix typos in comments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ enum Action {
 }
 
 /// `BTree` is where the information `Sender` is contained.
-/// It's inner implementation has a tuple containing the action to be taken as well as a oneshot channel to receive data.
+/// Its inner implementation has a tuple containing the action to be taken as well as a oneshot channel to receive data.
 /// To start the `BTree` thread just execute `BTree::start(buffer_size: usize)`. If you `buffer_size` is too short
 /// it may cause synchronization problems, so it should be well ajusted to your application needs.
 pub struct BTree {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@ enum Action {
     RemoveEntry(String),
 }
 
-/// `BTree` is where the informatio `Sender` is contained.
-/// Its inner implementation has a tuple containing the action to be taken as well as a oneshot channel to receive data.
+/// `BTree` is where the information `Sender` is contained.
+/// It's inner implementation has a tuple containing the action to be taken as well as a oneshot channel to receive data.
 /// To start the `BTree` thread just execute `BTree::start(buffer_size: usize)`. If you `buffer_size` is too short
 /// it may cause synchronization problems, so it should be well ajusted to your application needs.
 pub struct BTree {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,7 @@ impl BTree {
 
     /// Method `keys` is equivalent to [`std::collection::BTreeMap keys`](https://doc.rust-lang.org/std/collections/struct.BTreeMap.html#method.keys),
     /// It returns a vector containing all the keys sorted.
-    /// For `BTree` the keys are always `Strings`.
+    /// For `BTree` the keys are always `String`.
     pub async fn keys(&self) -> Result<Vec<String>, String> {
         let tx = self.tx.clone();
         let (tx_o, rx_o) = oneshot::channel();


### PR DESCRIPTION
Fix typo on struct `BTree` documentation and giving a suggestion on `keys` method documentation.